### PR TITLE
Updates FiatToken contract to include transfer fees; updates tests to test transfer fees

### DIFF
--- a/contracts/FiatToken.sol
+++ b/contracts/FiatToken.sol
@@ -35,57 +35,6 @@ contract FiatToken is MintableToken {
   }
 
   /**
-   * @dev Approve the passed address to spend the specified amount of tokens with fees on behalf of msg.sender.
-   *
-   * Beware that changing an allowance with this method brings the risk that someone may use both the old
-   * and the new allowance by unfortunate transaction ordering. One possible solution to mitigate this
-   * race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards:
-   * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
-   * @param _spender The address which will spend the funds.
-   * @param _value The amount of tokens to be spent.
-   */
-  function approveWithFee(address _spender, uint256 _value) public returns (bool) {
-    uint256 feeAmount;
-    uint256 totalAmount; 
-    (feeAmount, totalAmount) = getTransferFee(_value);
-    return approve(_spender, totalAmount);
-  }
-
-  /**
-   * @dev Increase the amount of tokens with fees that an owner allowed to a spender.
-   *
-   * approve should be called when allowed[_spender] == 0. To increment
-   * allowed value is better to use this function to avoid 2 calls (and wait until
-   * the first transaction is mined)
-   * From MonolithDAO Token.sol
-   * @param _spender The address which will spend the funds.
-   * @param _addedValue The amount of tokens to increase the allowance by.
-   */
-  function increaseApprovalWithFee(address _spender, uint _addedValue) public returns (bool) {
-    uint256 feeAmount;
-    uint256 totalAmount; 
-    (feeAmount, totalAmount) = getTransferFee(_addedValue);
-    return increaseApproval(_spender, totalAmount);
-  }
-
-  /**
-   * @dev Decrease the amount of tokens with fees that an owner allowed to a spender.
-   *
-   * approve should be called when allowed[_spender] == 0. To decrement
-   * allowed value is better to use this function to avoid 2 calls (and wait until
-   * the first transaction is mined)
-   * From MonolithDAO Token.sol
-   * @param _spender The address which will spend the funds.
-   * @param _subtractedValue The amount of tokens to decrease the allowance by.
-   */
-  function decreaseApprovalWithFee(address _spender, uint _subtractedValue) public returns (bool) {
-    uint256 feeAmount;
-    uint256 totalAmount; 
-    (feeAmount, totalAmount) = getTransferFee(_subtractedValue);
-    return decreaseApproval(_spender, totalAmount);
-  }
-
-  /**
    * @dev Transfer tokens from one address to another. The allowed amount includes the transfer value and transfer fee.
    * Validates that the totalAmount <= the allowed amount for the sender on the from account.
    * @param _from address The address which you want to send tokens from
@@ -98,10 +47,10 @@ contract FiatToken is MintableToken {
     uint256 totalAmount; 
     (feeAmount, totalAmount) = getTransferFee(_value);
 
-    require(totalAmount <= allowed[_from][msg.sender]);
+    require(_value <= allowed[_from][msg.sender]);
 
     doTransfer(_from, _to, _value, feeAmount, totalAmount);
-    allowed[_from][msg.sender] = allowed[_from][msg.sender].sub(totalAmount);
+    allowed[_from][msg.sender] = allowed[_from][msg.sender].sub(_value);
     return true;
   }
 


### PR DESCRIPTION
-Adds solidity functions for transfer, transferFrom with fees
-Adds tests:
    ✓ should set fees and complete transferFrom with fees
    ✓ should set long-decimal fees and complete transferFrom with fees
    ✓ should set fees and and fail to complete transferFrom with insufficient balance to cover fees 
    ✓ should set long-decimal fees and complete transfer with fees 
    ✓ should set long-decimal fees and complete transfer with fees from non-owner 