### PR TITLE
Increase timeout limit to 15 minutes (from 10 minutes) to avoid tests timing out

### DIFF
--- a/ci/codebuild.yml
+++ b/ci/codebuild.yml
@@ -53,7 +53,7 @@ Resources:
         Auth:
           Type: OAUTH
         GitCloneDepth: 1
-      TimeoutInMinutes: 10
+      TimeoutInMinutes: 15
 
   CodeBuildBucket:
     Type: "AWS::S3::Bucket"


### PR DESCRIPTION
Tests now exceed 10 min. Tests should probably be parallelized but increasing timeout limit for now.