### PR TITLE
Enforces warnings as errors in build

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -13,7 +13,7 @@ phases:
     commands:
       - echo Build started on `date`
       - mkdir -p build/logs
-      - truffle compile
+      - truffle compile --strict
       - npm test
 
 artifacts:


### PR DESCRIPTION
Ensures warnings are treated as errors and must be done outside of npm test as solidity-coverage (used in npm test) alters functions to add events (such as removing "pure" function modifiers) that can result in warnings. 