### PR TITLE
Fixes lack of check for blacklisted msg.sender in UpgradedFiatToken transferFrom

### DIFF
--- a/contracts/test/UpgradedFiatToken.sol
+++ b/contracts/test/UpgradedFiatToken.sol
@@ -137,7 +137,7 @@ contract UpgradedFiatToken is FiatToken, UpgradedContract {
      * @param _to address The address which you want to transfer to
      * @param _value uint256 the amount of tokens to be transferred
     */
-    function doTransferFrom(address _sender, address _from, address _to, uint256 _value) private {
+    function doTransferFrom(address _sender, address _from, address _to, uint256 _value) notBlacklisted(_sender) private {
         uint256 allowed;
         allowed = getAllowed(_from, _sender);
 


### PR DESCRIPTION
Negative test "should fail to transferFrom from blacklisted msg.sender" uncovered the lack of a check for a blacklisted msg.sender in the UpgradedFiatToken contract. 