### PR TITLE
Replaced FiatToken with FiatTokenV1 in validate.js

### DIFF
--- a/validate/validate.js
+++ b/validate/validate.js
@@ -23,7 +23,7 @@ var TOTALSUPPLY =  0;
 var PAUSED = false
 
 // Name of current implementation artifact as stored in ./build/contracts/*.json
-var FiatToken = artifacts.require("FiatToken");
+var FiatToken = artifacts.require("FiatTokenV1");
 
 // Name of current proxy artifact as stored in ./build/contracts/*.json
 var FiatTokenProxy = artifacts.require("FiatTokenProxy");


### PR DESCRIPTION
Accidentally used old contract ABI in PR-188.