### PR TITLE
remove decoder dependency on truffle and ganache

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "lite-server",
     "truffle-test": "scripts/start-ganache.sh && truffle test",
-    "test": "scripts/start-ganache.sh && truffle test scripts/dataEncodingTests.js && ./node_modules/.bin/solidity-coverage"
+    "test": "scripts/start-ganache.sh && truffle test scripts/tests/dataEncodingTests.js && ./node_modules/.bin/solidity-coverage"
   },
   "repository": {
     "type": "git",

--- a/scripts/decodeTxData.js
+++ b/scripts/decodeTxData.js
@@ -1,30 +1,49 @@
-// Decodes "data" field of ethereum transactions
-// newest ABI should be built before running this script (`truffle compile` generates build/contracts directory)
-// args:
-// "--contract": name of contract
-// "--data": hex used as input data to ethereum transaction. Encodes function name, parameter types, and parameter values
-// "--filename": (optional) file name used for output file. If none is supplied, output is only sent to standard output stream
-
-// example:
-// `truffle exec decodeTxData.js --contract FiatTokenV1 --data 0x4e44d9560000000000000000000000009c08210cc65b5c9f1961cdbd9ea9bf017522464d000000000000000000000000000000000000000000000000000000003b9aca00`
-// { name: 'configureMinter',
-//  types: [ 'address', 'uint256' ],
-//  inputs: [ '9c08210cc65b5c9f1961cdbd9ea9bf017522464d', 1000000000 ] }
 const InputDataDecoder = require('ethereum-input-data-decoder')
 var fs = require('fs')
-var path = require('path')
 var mkdirp = require('mkdirp')
 var args = process.argv;
 
-var dataFlagIndex = args.indexOf("--data");
-var data = args[dataFlagIndex + 1]
-var contractNameFlagIndex = args.indexOf("--contract")
-var contractName = args[contractNameFlagIndex + 1]
-var fileNameFlagIndex = args.indexOf("--filename")
+var helpText = `Decodes "data" field of ethereum transactions
+args:
+"--truffle-artifact" or "--abi-path":
+  "--truffle-artifact": name of truffle-artifact (contract name)
+  "--abi-path": /path/to/abi.json (contents of file should be one abi array)
+"--data": hex used as input data to ethereum transaction. Encodes function name, parameter types, and parameter values
+"--filename": (optional) file name used for decoded output. File is saved to ./decoded_data/<filename>.json. If no filename is provided, output is logged to stdout.
 
-var contract = artifacts.require(contractName)
-var abi = contract.abi
-var decoder = new InputDataDecoder(abi)
+example using truffle with --truffle-artifact:
+- in process 1, run ganache: $ ganache-cli
+- in process 2, compile contracts to /build/contracts/ folder: $ truffle compile
+- in process 2, run decoder: $ truffle exec decodeTxData.js --truffle-artifact FiatTokenV1 --data 0x4e44d9560000000000000000000000009c08210cc65b5c9f1961cdbd9ea9bf017522464d000000000000000000000000000000000000000000000000000000003b9aca00$ --filename configureMinter
+Output: new file is created at decoded_data/configureMinter.json:
+{  
+   "name":"configureMinter",
+   "types":[  
+      "address",
+      "uint256"
+   ],
+   "inputs":[  
+      "9c08210cc65b5c9f1961cdbd9ea9bf017522464d",
+      "1000000000"
+   ]
+}
+
+example using just node with --abi-path:
+- (ensure that correct abi is located at --abi-path)
+- run decoder: $ node decodeTxData.js --abi-path ./tests/FiatTokenProxy_abi.json --data 4f1ef286000000000000000000000000023fe1585d8361f0584aaa78c152f94cdcff7b3000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000064d76c43c60000000000000000000000000000000000000000000000000000000000000001000000000000000000000000aca94ef8bd5ffee41947b4585a84bda5a3d3da6e000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000 --filename upgradeToAndCall
+Output: new file is created at decoded_data/upgradeToAndCall.json:
+{  
+   "name":"upgradeToAndCall",
+   "types":[  
+      "address",
+      "bytes"
+   ],
+   "inputs":[  
+      "023fe1585d8361f0584aaa78c152f94cdcff7b30",
+      "d76c43c60000000000000000000000000000000000000000000000000000000000000001000000000000000000000000aca94ef8bd5ffee41947b4585a84bda5a3d3da6e000000000000000000000000000000000000000000000000000000000000000c"
+   ]
+}
+`
 
 function toHexString(byteArray) {
   return Array.from(byteArray, function(byte) {
@@ -33,6 +52,39 @@ function toHexString(byteArray) {
 }
 
 function decode() {
+  var helpFlagIndex = args.indexOf("--help");
+  if (helpFlagIndex != -1) {
+    console.log(helpText)
+    return
+  }
+
+  var dataFlagIndex = args.indexOf("--data");
+  var data = args[dataFlagIndex + 1]
+  var truffleArtifactFlagIndex = args.indexOf("--truffle-artifact")
+  var abiPathFlagIndex = args.indexOf("--abi-path")
+  var outputFileNameFlagIndex = args.indexOf("--filename")
+
+  var abi;
+
+  if (abiPathFlagIndex != -1) {
+    var abiPathIndex = args[abiPathFlagIndex + 1]
+    var abiStr = fs.readFileSync(abiPathIndex, "utf8")
+    abi = JSON.parse(abiStr)
+  } else {
+    if (truffleArtifactFlagIndex != -1) {
+      var truffleArtifactName = args[truffleArtifactFlagIndex + 1]
+      var truffleArtifact = artifacts.require(truffleArtifactName)
+      abi = truffleArtifact.abi
+    } else {
+      throw new Error(`ABI is missing. Pass in the ABI with one of the following flags:
+        --abi-path /path/to/abi.json
+        --truffle-artifact nameOfContract
+        print full instructions with: --help
+        `)
+    }
+  }
+
+  var decoder = new InputDataDecoder(abi)
   result = decoder.decodeData(data)
     for (i = 0; i < result.inputs.length; i++) {
       // if the the type is object and corresponding type in type array is uint, try to parse it
@@ -45,16 +97,17 @@ function decode() {
     }
   var decodedDataJson = JSON.stringify(result)
 
-  if (fileNameFlagIndex != -1) {
-    fileName = args[fileNameFlagIndex + 1]
+  if (outputFileNameFlagIndex != -1) {
+    outputFileName = args[outputFileNameFlagIndex + 1]
     mkdirp.sync('decoded_data')
-    fs.writeFileSync('decoded_data/' + fileName + '.json', decodedDataJson, 'utf8');
+    fs.writeFileSync('decoded_data/' + outputFileName + '.json', decodedDataJson, 'utf8');
   } else {
     console.log(decodedDataJson)
   }
 }
 
+decode()
+
 module.exports = async function(callback) {
-  decode()
   callback()
 }

--- a/scripts/tests/dataEncodingTests.js
+++ b/scripts/tests/dataEncodingTests.js
@@ -32,7 +32,7 @@ describe('transaction data encoding and decoding tests', function() {
   })
 
   it("td005 should decode a data string and output decoded result to stdout stream", async function () {
-    const { stdout, stderr } = await exec("truffle exec ./scripts/decodeTxData.js --contract FiatTokenV1 --data " + configureMinterData);
+    const { stdout, stderr } = await exec("truffle exec ./scripts/decodeTxData.js --truffle-artifact FiatTokenV1 --data " + configureMinterData);
 
     // trim extra output from truffle
     var bracketIndex = stdout.indexOf("{")
@@ -46,8 +46,8 @@ describe('transaction data encoding and decoding tests', function() {
   })
 
   it('td006 should decode a data string and output decoded result to a file', async function () {
-    await exec("truffle exec ./scripts/decodeTxData.js --contract FiatTokenV1 --data " + configureMinterData + " --filename configureMinterTest");
-    var decodedDataJson = fs.readFileSync('decoded_data/configureMinterTest.json');
+    await exec("truffle exec ./scripts/decodeTxData.js --truffle-artifact FiatTokenV1 --data " + configureMinterData + " --filename configureMinterTest");
+    var decodedDataJson = fs.readFileSync('./scripts/decoded_data/configureMinterTest.json');
     var decodedData = JSON.parse(decodedDataJson);
     assert.equal(decodedData.name, "configureMinter")
     assert.equal(decodedData.types[0], "address")
@@ -57,8 +57,23 @@ describe('transaction data encoding and decoding tests', function() {
   })
 
   it('td007 should decode a data string for FiatTokenProxy and its byte array input to a hex string', async function () {
-    await exec ("truffle exec scripts/decodeTxData.js --contract FiatTokenProxy --data " + upgradeToAndCallData + " --filename initV2Test")
-    var decodedDataJson = fs.readFileSync('decoded_data/initV2Test.json');
+    await exec ("truffle exec scripts/decodeTxData.js --truffle-artifact FiatTokenProxy --data " + upgradeToAndCallData + " --filename upgradeToAndCallTruffleTest")
+    var decodedDataJson = fs.readFileSync('./scripts/decoded_data/upgradeToAndCallTruffleTest.json');
+    var decodedData = JSON.parse(decodedDataJson);
+    assert.equal(decodedData.name, "upgradeToAndCall")
+    assert.equal(decodedData.types[0], "address")
+    assert.equal(decodedData.types[1], "bytes")
+    assert.equal(decodedData.inputs[0], "023fe1585d8361f0584aaa78c152f94cdcff7b30")
+    assert.equal(decodedData.inputs[1], initV2Data)
+  })
+
+  it('td008 should decode a data string using --abi-path', async function () {
+    fiatTokenProxyCompiled = fs.readFileSync("./build/contracts/FiatTokenProxy.json", "utf8");
+    fiatTokenProxyJson = JSON.parse(fiatTokenProxyCompiled)
+    fs.writeFileSync("./scripts/tests/FiatTokenProxy_abi.json", JSON.stringify(fiatTokenProxyJson.abi), 'utf8')
+
+    await exec ("cd scripts && node ./decodeTxData.js --abi-path ./tests/FiatTokenProxy_abi.json --data " + upgradeToAndCallData + " --filename upgradeToAndCallNodeTest")
+    var decodedDataJson = fs.readFileSync('./scripts/decoded_data/upgradeToAndCallNodeTest.json');
     var decodedData = JSON.parse(decodedDataJson);
     assert.equal(decodedData.name, "upgradeToAndCall")
     assert.equal(decodedData.types[0], "address")


### PR DESCRIPTION
To run the decoder with just node, use
`--abiPath /path/to/abi.json
`
getting the abi with truffle's artifacts.require is still supported, but `--contract` is renamed to --`truffle-artifact`

`--help` prints decoder's help information