### PR TITLE
chore(deps): gha node 20 upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup CI Environment
         uses: ./.github/composite-actions/setup-ci
@@ -67,7 +67,7 @@ jobs:
             invert: true
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup CI Environment
         uses: ./.github/composite-actions/setup-ci

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
     if: ${{ github.event.label.name == 'needs_coverage' }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup CI Environment
         uses: ./.github/composite-actions/setup-ci


### PR DESCRIPTION
## Summary
upgrade github action versions to use node 20 runtime

actions/checkout v3 -> v4 Release notes: https://github.com/actions/checkout/releases/tag/v4.0.0