### PR TITLE
Update HackerOne program link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,5 +4,5 @@
 
 Please do not file public issues on Github for security vulnerabilities. All
 security vulnerabilities should be reported to Circle privately, through
-Circle's [Vulnerability Disclosure Program](https://hackerone.com/circle).
-Please read through the program policy before submitting a report.
+Circle's [Bug Bounty Program](https://hackerone.com/circle-bbp). Please read
+through the program policy before submitting a report.


### PR DESCRIPTION
The VDP program now stops accepting new reports, so all new reports should go to BBP.