### PR TITLE
docs: Fix typo in contract documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ There are 2 main contracts - an implementation contract
 logic for FiatToken's functionalities, and a proxy contract
 ([`FiatTokenProxy.sol`](./contracts/v1/FiatTokenProxy.sol)) that redirects
 function calls to the implementation contract. This allows upgrading FiatToken's
-functionalities, as a new implementation contact can be deployed and the Proxy
+functionalities, as a new implementation contract can be deployed and the Proxy
 can be updated to point to it.
 
 ## FiatToken features


### PR DESCRIPTION
## Summary

Spotted and fixed a small typo in the documentation—"contact" should be "contract" in the explanation of the proxy upgrade pattern. Now the sentence reads correctly.
