### PR TITLE
Update foundryup command to use correct flag

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -41,7 +41,7 @@ fi
 if ! command -v forge &> /dev/null || [ ! "$(forge -V | grep -Eo '\b\w{7}\b')" = $(echo $FOUNDRY_VERSION | cut -c '9-15') ]
 then
   echo "Installing foundry at $FOUNDRY_VERSION..."
-  foundryup --version $FOUNDRY_VERSION
+  foundryup --install $FOUNDRY_VERSION
 fi
 
 npm install -g dotenv-cli@7.3.0


### PR DESCRIPTION
## Summary
Using the correct foundryup command to install the intended foundryup version, based on the foundry readme: https://github.com/foundry-rs/foundry/blob/master/foundryup/README.md 
