### PR TITLE
chore(stepsecurity): update workflows to use custom hosted runners with built-in StepSecurity

### DIFF
--- a/.github/workflows/bytecode-verification.yml
+++ b/.github/workflows/bytecode-verification.yml
@@ -22,10 +22,10 @@ on:
 
 jobs:
   bytecode-verification:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup CI Environment
         uses: ./.github/composite-actions/setup-ci

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -27,17 +27,17 @@ permissions:
 
 jobs:
   post_run_hardhat_tests:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     steps:
       - name: Download test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: junit-report-*
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish combined test report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe # v4
         with:
           check_name: upload_test_results
           job_summary: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ env:
 
 jobs:
   run_ci_tests:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup CI Environment
         uses: ./.github/composite-actions/setup-ci
@@ -55,7 +55,7 @@ jobs:
           ENABLE_GAS_REPORTER: true
 
   run_hardhat_tests:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     strategy:
       fail-fast: false
       matrix:
@@ -69,7 +69,7 @@ jobs:
             invert: true
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup CI Environment
         uses: ./.github/composite-actions/setup-ci
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload test results to artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-report-${{ hashFiles('report/junit.xml') }}
           path: report/junit.xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,11 +25,11 @@ concurrency:
 
 jobs:
   run_coverage:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     if: ${{ github.event.label.name == 'needs_coverage' }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup CI Environment
         uses: ./.github/composite-actions/setup-ci
@@ -42,7 +42,7 @@ jobs:
 
       - name: Report coverage to PR
         id: report-coverage
-        uses: sidx1024/report-nyc-coverage-github-action@v1.2.7
+        uses: sidx1024/report-nyc-coverage-github-action@8adfb1be4a23deee7b1eaf0dc3000317eedaeab5 # v1.2.7
         with:
           coverage_file: "coverage/coverage-summary.json"
           base_coverage_file: ""
@@ -54,7 +54,7 @@ jobs:
           fromJSON(steps.report-coverage.outputs.total_branches_coverage_percent_raw) < 98 ||
           fromJSON(steps.report-coverage.outputs.total_statements_coverage_percent_raw) < 100 ||
           fromJSON(steps.report-coverage.outputs.total_functions_coverage_percent_raw) < 100
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             core.setFailed('Test coverage is under the threshold')


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions workflows to use custom hosted runners that have StepSecurity built-in, removing the need for the explicit StepSecurity harden-runner action.

## What Changed
- Removed step-security/harden-runner action steps (no longer needed as StepSecurity is built into custom runners)
- Removed id-token: write permissions (no longer needed without the StepSecurity action)
- Updated runs-on from ubuntu-latest to github-hosted-small (custom runners with built-in StepSecurity)
- Converted non-circlefin action versions to commit SHAs with version comments for security pinning (e.g., actions/checkout@abc123 # v3.6.0)
- circlefin GitHub actions remain unchanged

## Purpose
Our custom hosted runners (github-hosted-small) now have StepSecurity built-in at the runner level, so we no longer need to add it as an explicit step in each workflow. This simplifies our workflows while maintaining the same security posture.

## Testing
- All workflow syntax changes have been validated
- No functional changes to workflow behavior
- StepSecurity protection is maintained via the custom runners
- Review the diff to ensure only intended changes occurred