### PR TITLE
chore(ci): bump GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/bytecode-verification.yml
+++ b/.github/workflows/bytecode-verification.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup CI Environment
         uses: ./.github/composite-actions/setup-ci

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           bucket: circle-cicd-artifacts
           pattern: junit-report-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup CI Environment
         uses: ./.github/composite-actions/setup-ci
@@ -69,7 +69,7 @@ jobs:
             invert: true
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup CI Environment
         uses: ./.github/composite-actions/setup-ci
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload test results to artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-report-${{ hashFiles('report/junit.xml') }}
           path: report/junit.xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
     if: ${{ github.event.label.name == 'needs_coverage' }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup CI Environment
         uses: ./.github/composite-actions/setup-ci
@@ -54,7 +54,7 @@ jobs:
           fromJSON(steps.report-coverage.outputs.total_branches_coverage_percent_raw) < 98 ||
           fromJSON(steps.report-coverage.outputs.total_statements_coverage_percent_raw) < 100 ||
           fromJSON(steps.report-coverage.outputs.total_functions_coverage_percent_raw) < 100
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             core.setFailed('Test coverage is under the threshold')


### PR DESCRIPTION
## Summary

Bulk SHA-pin update of GitHub Actions to their latest Node-24-compatible release. Pre-emptive migration ahead of GitHub Actions runner Node 20 removal in Fall 2026.

## Actions bumped

- `actions/checkout@v4` → `df4cb1c0…` (v6.0.3)
- `actions/download-artifact@v4` → `3e5f45b2…` (v8.0.1)
- `actions/upload-artifact@v4` → `043fb46d…` (v7.0.1)
- `actions/github-script@v7` → `3a2844b7…` (v9.0.0)

## Verification

Every emitted SHA was verified via `gh api /repos/<owner>/<repo>/commits/<sha>` before commit.

## Background

Node 20 is being removed from GitHub Actions runners in Fall 2026 (see [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This PR pre-emptively bumps every pinned third-party action to its first Node-24-compatible release so the workflows keep running on the new runner default.